### PR TITLE
🚑 Add permissions for SBOM publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       attestations: write
-      contents: read
+      contents: write
       id-token: write
       packages: write
     steps:


### PR DESCRIPTION
This pull request:

- Adds workflow permissions as per https://github.com/anchore/sbom-action?tab=readme-ov-file#permissions

Signed-off-by: Jacob Woffenden <jacob@woffenden.io> 